### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,100 @@
 # Prismic Slice Library Example
 
-Brought to you by Prismic Solution Engineering Team
+Brought to you by Prismic Solution Engineering Team.
 
-_Prerequisite:_
-- _have node v18 or above installed on your local machine : https://nodejs.org/en/_
-- _have a Prismic and Next.js project built with SliceMachine (slice-machine-ui v1.26.0 or above)_
-- _have Tailwind CSS installed for the styling of the page_
+### Prerequisites
 
-> This project is a simplified version of Prismic Next.js Demo project aka [slicify](https://github.com/prismicio-solution-engineering/slicify-app)
+To make use of this project, you need to have the following:
 
-You can see this slice library deployed here: [here](https://slicify-library.vercel.app/slice-library)
+  - NodeJS v18 or above installed on your local machine: https://nodejs.org/en/,
+  - a Prismic and Next.js project built with Slice Machine (slice-machine-ui v1.26.0 or above),
+  - already Tailwind CSS used for styling your project (or willingness to add it for Slice Library)
 
-### Step 1. Add the `/app/slice-library` folder to your `/app` folder
+> [!NOTE]
+> This project is a simplified version of Prismic Next.js Demo project a.k.a.
+> [slicify](https://github.com/prismicio-solution-engineering/slicify-app)
 
-This folder contains three files:
-- [page.tsx](https://github.com/prismicio-solution-engineering/slicify-library/blob/main/app/slice-library/page.tsx) : the page itself, holds logic to get slice data (models and mocks)
-- [SliceLibrary.tsx](https://github.com/prismicio-solution-engineering/slicify-library/blob/main/app/slice-library/SliceLibrary.tsx) : UI server component to display Slices on the page
-- [SliceLibraryNav.tsx](https://github.com/prismicio-solution-engineering/slicify-library/blob/main/app/slice-library/SliceLibraryNav.tsx) : UI client component to handle sidebar navigation 
+You can see this slice library deployed [here](https://slicify-library.vercel.app/slice-library).
 
-### Step 2. Install dependency
+### Step 1. Add the `/app/slice-library` directory to your project
+
+The directory contains components and styles for the slice library page. This directory needs to be copied to your `app` directory,
+which — depending on the Next.js project configuration — can be located at either `<your-project>/app` or `<your-project>/src/app`.
+
+> [!TIP]
+> If you are not using TypeScript and don't want to set it up for your project, a simple way to produce plain JavaScript files
+> without any TypeScript annotations is the following command (`<this-repo>` and `<your-project>` are of course placeholders,
+> please adjust them to your current working directory):
+> 
+> ```bash
+> npx sucrase <this-repo>/app/slice-library -d <your-project>/app/slice-library --transforms typescript,jsx --jsx-runtime preserve
+> ```
+>
+> It will take all the TypeScript files for the `/slice-library` page, strip all TypeScript annotations from the code and place
+> resulting files in the `app/slice-library` of your project. You will still have to copy the CSS file by hand if you need it, as
+> the command transforms only TypeScript files.
+
+There are three main files you need to copy:
+
+  - [page.tsx](https://github.com/prismicio-solution-engineering/slicify-library/blob/main/app/slice-library/page.tsx) — provides the main
+    component for the slice library page and holds code to load model and mock data for all your defined slice libraries,
+  - [SliceLibrary.tsx](https://github.com/prismicio-solution-engineering/slicify-library/blob/main/app/slice-library/SliceLibrary.tsx) —
+    provides a UI server component to display all your slices on the page,
+  - [SliceLibraryNav.tsx](https://github.com/prismicio-solution-engineering/slicify-library/blob/main/app/slice-library/SliceLibraryNav.tsx) —
+    provides a UI client component to handle sidebar navigation.
+
+We also provide those two optional files for your convenience:
+
+  - [layout.tsx](https://github.com/prismicio-solution-engineering/slicify-library/blob/main/app/slice-library/layout.tsx) —
+    provides a basic, empty layout for your slice library in case you don't have a global layout, or it will interfere with
+    slice library styling. Feel free to adjust it to your needs or remove it,
+  - [styles.css](https://github.com/prismicio-solution-engineering/slicify-library/blob/main/app/slice-library/styles.css) —
+    provides Tailwind CSS styles for the slice library. If you already have a layout that includes your Tailwind CSS styling
+    globally, feel free to remove it.
+
+### Step 2. Setup dependencies
+
+You will need to add those dependencies for the slice library page:
 
 ```bash
-npm i @headlessui/react
+npm add @headlessui/react @prismicio/api-renderer
 ```
+
+If you don't already use Tailwind CSS, you can follow the steps below to set it up:
+
+<details>
+<summary>
+Tailwind CSS setup
+</summary>
+
+* install Tailwind CSS and it's dependencies:
+  ```bash
+  npm add tailwindcss postcss autoprefixer
+  ```
+* initialise Tailwind CSS in your repository:
+  ```bash
+  npx tailwindcss init -p
+  ```
+* include the slice library page in your Tailwind CSS configuration, if it's not already covered by other globs:
+  ```javascript
+  module.exports = {
+    content: [
+      // When not using the `src` directory:
+      "./app/slice-library/**/*.{js,ts,jsx,tsx,mdx}"
+  
+      // Or, if using `src` directory:
+      "./src/app/slice-library/**/*.{js,ts,jsx,tsx,mdx}",
+    ],
+    ...
+  }
+  ```
+* ensure Tailwind CSS styles are imported — e.g. by using included layout and stylesheet, or analogous
+  configuration specific to how your project is set up.
+</details>
 
 ### Step 3. Optional (only if you have multiple slice-libraries)
 
-Edit the SliceLibrary.tsx file to include all your slice libraries components
+Edit the `SliceLibrary.tsx` file to include all your slice libraries components
 
 ```ts
 // If needed, Add components from all your slice libraries if you have multiple:
@@ -37,42 +105,51 @@ Edit the SliceLibrary.tsx file to include all your slice libraries components
 import { components as __allComponents } from '@/slices/index'
 ```
 
-### Step 4. Run your app and go to `slice-library` page
+### Step 4. Run your app and go to the `/slice-library` page
 
 ```bash
 npm run dev
 ```
 
-You can now access your slice-library here : [http://localhost:3000/slice-library](http://localhost:3000/slice-library) .
+You can now access your `/slice-library` page here: [http://localhost:3000/slice-library](http://localhost:3000/slice-library).
 
 
-### Step 5. Run SliceMachine and edit your mocks
+### Step 5. Run Slice Machine and edit your mocks
 
 ```bash
 npm run slicemachine
 ```
 
-You can now access your SliceMachine here : [http://localhost:9999](http://localhost:9999) .
+You can now access your Slice Machine here: [http://localhost:9999](http://localhost:9999).
 
-You can then go into each of your slices and edit the mock data by clicking the simulate button at the top right. This mock data will be used to build your slice-library page. Don't forget to save your mocks.
+You can then go into each of your slices and edit the mock data by clicking the simulate button at the top right. This mock data will be
+used to build your `/slice-library` page. Don't forget to save your mocks.
 
-SliceMachine generates mocks automatically but you might want to make them prettier!
+Slice Machine generates mocks automatically, but you might want to make them prettier!
 
 # Troubleshooting
 
-- If you have issues with Next.js not displaying your slices when deployed, you can add this code to your next.config to specify Next.js to uses your /slices folder when building your slice-library page, as shown [here](https://github.com/prismicio-solution-engineering/slicify-app/blob/main/next.config.mjs#L5-L9)
+- If you have issues with Next.js not displaying your slices when deployed, you can add this configuration to your `next.config.js`, so that
+  Next.js  knows to include your `/slices` folder when building your project, as shown [here](https://github.com/prismicio-solution-engineering/slicify-app/blob/main/next.config.mjs#L5-L9):
 
-```
-experimental:{
-      outputFileTracingIncludes: {
-        '/slice-library': ['./slices/**/*']
-      }
-},
-```
+  ```js
+  experimental: {
+    outputFileTracingIncludes: {
+      "/slice-library": ["./slices/**/*"]
+    }
+  },
+  ```
 
-- Some slices might fail if the Slice components are not checking if slice data exist before using them (especially for non-filled content relationships, integration fields...). In these two cases the mocks are not generated by SM, so there is no data to display at the moment, this will be added later. You can edit your slices to check for that content so the page can be built.
+- Some slices might fail if the slice data is empty (especially for unfilled content relationships or integration fields). In these cases
+  the mocks are not generated by the Slice Machine currently, so the data might be missing (this feature will be added in future). You can
+  modify your slice components to handle missing data gracefully, so the slice library page works without issues.
+
+- If you include TypeScript files in a vanilla–JavaScript–based project, Next.js will helpfully try to set this project up for TypeScript
+  for you. However, this automatic process doesn't respect alias configuration at the time of writing — if building your page fails with
+  errors about `@/prismicio` being unresolvable, ensure that alias configuration at `compilerOptions.path` matches between `jsconfig.json`
+  and `tsconfig.json`.
 
 ## Disclaimer
 
-This project is made to test out Prismic, Slices used in this project are subject to Tailwind UI license : https://tailwindui.com/license
-Images used in this project are from unsplash.com, please find unsplash license here : https://unsplash.com/license
+This project is made to test out Prismic, Slices used in this project are subject to Tailwind UI license: https://tailwindui.com/license.  
+Images used in this project are from unsplash.com, please find unsplash license here: https://unsplash.com/license.

--- a/app/slice-library/SliceLibrary.tsx
+++ b/app/slice-library/SliceLibrary.tsx
@@ -26,7 +26,7 @@ export function SliceLibrary({ libraries }: { libraries: SliceLibrary[] }) {
     <div>
       {/* Static sidebar for desktop */}
       <SliceLibraryNav libraries={libraries} />
-      <div className="flex flex-1 flex-col md:pl-64">
+      <div className="flex flex-1 flex-col md:pl-64 bg-gray-50">
         <div className="sticky top-0 z-10 flex h-16 flex-shrink-0 bg-white shadow">
           <div className="m-auto max-w-7xl px-4 sm:px-6 md:px-8">
             <h1 className="text-2xl font-semibold text-gray-900">
@@ -54,7 +54,7 @@ function SliceList({ libraries }: { libraries: SliceLibrary[] }) {
         const key = `${library.name}-${id}-${variation.id}`;
 
         let variationFragment: ReactNode = (
-          <div className="flex flex-wrap bg-slate-50 h-64 rounded-md justify-center content-center text-xl uppercase bold text-slate-500">
+          <div className="flex flex-wrap bg-gray-100 h-64 p-1.5 rounded-md border border-gray-200 justify-center content-center text-xl uppercase bold text-gray-500">
             Mock missing for this variation
           </div>
         );
@@ -72,7 +72,7 @@ function SliceList({ libraries }: { libraries: SliceLibrary[] }) {
           ] as SliceZoneLike;
 
           variationFragment = (
-            <div className="isolate bg-white rounded-md">
+            <div className="isolate bg-white p-1.5 rounded-md border border-gray-200">
               <SliceZone slices={mockApi} components={__allComponents} />
             </div>
           );

--- a/app/slice-library/SliceLibrary.tsx
+++ b/app/slice-library/SliceLibrary.tsx
@@ -1,327 +1,134 @@
-import React from "react";
-import { SliceZone } from "@prismicio/react";
-import { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
-import { SharedSliceContent } from "@prismicio/types-internal/lib/content";
-import { SharedSlice as APISharedSlice, AnyRegularField, RTNode } from "@prismicio/client";
+import React, { ReactNode } from "react";
+
+import { SliceZone, SliceZoneLike } from "@prismicio/react";
+import {
+  ApiDocument,
+  Extensions,
+  LinkResolver,
+  RenderContext,
+} from "@prismicio/api-renderer/lib/models";
+import { SharedSliceRenderer } from "@prismicio/api-renderer";
 
 // If needed, Add components from all your slice libraries if you have multiple:
 // import { components as ecommerceComponents } from '@/slices/blog/index'
 // import { components as marketingComponents } from '@/slices/marketing/index'
 // const __allComponents = { ...ecommerceComponents, ...marketingComponents }
 
-import { components as __allComponents } from '@/slices/index'
+import { components as __allComponents } from "@/slices/index";
 
 // import Nav which is a client component using @headlessui/react
 import SliceLibraryNav from "./SliceLibraryNav";
 
-export function SliceLibrary({
-    libraries
-}: {
-    libraries: { slices: SharedSlice[], name: string, mocks: SharedSliceContent[][] }[]
-}) {
+import { type SliceLibrary } from "./page";
 
-    return (
-        <>
-            <div>
-                {/* Static sidebar for desktop */}
-                <SliceLibraryNav libraries={libraries} />
-                <div className="flex flex-1 flex-col md:pl-64">
-                    <div className="sticky top-0 z-10 flex h-16 flex-shrink-0 bg-white shadow">
-                        <div className="m-auto max-w-7xl px-4 sm:px-6 md:px-8">
-                            <h1 className="text-2xl font-semibold text-gray-900">Explore your Slice Libraries</h1>
-                        </div>
-                    </div>
-                    <main>
-                        <div className="mx-auto max-w-7xl px-4">
-                            {libraries.map((library, index) => {
-                                return (
-                                    library.slices.map((slice, sliceIndex) => {
-                                        return (
-                                            slice.variations.map((variation) => {
-                                                const type = slice.id;
+export function SliceLibrary({ libraries }: { libraries: SliceLibrary[] }) {
+  return (
+    <div>
+      {/* Static sidebar for desktop */}
+      <SliceLibraryNav libraries={libraries} />
+      <div className="flex flex-1 flex-col md:pl-64">
+        <div className="sticky top-0 z-10 flex h-16 flex-shrink-0 bg-white shadow">
+          <div className="m-auto max-w-7xl px-4 sm:px-6 md:px-8">
+            <h1 className="text-2xl font-semibold text-gray-900">
+              Explore your Slice Libraries
+            </h1>
+          </div>
+        </div>
+        <main>
+          <div className="mx-auto max-w-7xl px-4">
+            <SliceList libraries={libraries} />
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}
 
-                                                const key =
-                                                    "slice_type" in slice && slice.slice_type
-                                                        ? `${index}-${slice.slice_type}-${variation.id}`
-                                                        : `${index}-${JSON.stringify(slice)}-${JSON.stringify(slice)}`;
+function SliceList({ libraries }: { libraries: SliceLibrary[] }) {
+  const renderer = SharedSliceRenderer(renderContext);
 
-                                                const mock = library.mocks[sliceIndex].find(mock => mock.variation === variation.id)
-                                                const mockApi = mapEditorToAPIFormat(mock, type)
+  return libraries.map((library) =>
+    library.slices.map(({ model, mocks }) =>
+      model.variations.map((variation) => {
+        const id = model.id;
+        const key = `${library.name}-${id}-${variation.id}`;
 
-                                                return (
-                                                    <div className="py-20" id={slice.id + "__" + variation.id} key={key}>
-                                                        <div className="border-b border-gray-200 pb-5 mb-5">
-                                                            <h3 className="text-lg font-medium leading-6 text-gray-900">{slice.name}</h3>
-                                                            <p className="mt-2 max-w-4xl text-sm text-gray-500">
-                                                                {variation.name}
-                                                            </p>
-                                                        </div>
-                                                        <div className="isolate bg-white rounded-md">
-                                                            <SliceZone slices={[mockApi]} components={__allComponents} />
-                                                        </div>
-                                                    </div>
-                                                )
-                                            })
-                                        )
-                                    })
-                                );
-                            })}
-                        </div>
-                    </main>
-                </div>
+        let variationFragment: ReactNode = (
+          <div className="flex flex-wrap bg-slate-50 h-64 rounded-md justify-center content-center text-xl uppercase bold text-slate-500">
+            Mock missing for this variation
+          </div>
+        );
+
+        const mock = mocks[variation.id];
+
+        if (mock !== undefined) {
+          const renderedMock = renderer.renderV2(model, mock!) as object;
+          const mockApi = [
+            {
+              id,
+              slice_type: id,
+              ...renderedMock,
+            },
+          ] as SliceZoneLike;
+
+          variationFragment = (
+            <div className="isolate bg-white rounded-md">
+              <SliceZone slices={mockApi} components={__allComponents} />
             </div>
-        </>
-    );
-}
-
-//Below is the logic to transform mocks into API format, could be improved to use Prismic Internal Types.
-function mapEditorToAPIFormat(mock: SharedSliceContent | undefined, slice_type: string): APISharedSlice {
-    return (
-        {
-            id: slice_type,
-            slice_type: slice_type,
-            slice_label: null,
-            version: "",
-            variation: mock?.variation || "default",
-            primary: Object.fromEntries(
-                Object.entries(mock?.primary || {}).map(([key, value]) => [key, transformContent(value)])
-            ),
-            items: mock?.items.map((item) => {
-                const itemData: ItemValueType = {};
-                item.value.forEach((groupItem) => {
-                    itemData[groupItem[0]] = transformContent(groupItem[1]);
-                });
-                return itemData;
-            }) || []
+          );
         }
+
+        return (
+          <div className="py-20" id={key} key={key}>
+            <div className="border-b border-gray-200 pb-5 mb-5">
+              <h3 className="text-lg font-medium leading-6 text-gray-900">
+                {model.name}
+              </h3>
+              <p className="mt-2 max-w-4xl text-sm text-gray-500">
+                {variation.name}
+              </p>
+            </div>
+            {variationFragment}
+          </div>
+        );
+      })
     )
+  );
 }
 
-type ItemValueType = {
-    [key: string]: AnyRegularField | null;
+// An empty context that `SharedSliceRenderer` needs to work it's magic
+const renderContext: RenderContext = {
+  urlRewriter: {
+    optimizeImageUrl(originUrl: string) {
+      return originUrl;
+    },
+    rewriteImageUrl(view) {
+      return view.url || "/viewUrlMissing";
+    },
+    rewriteFileUrl(originUrl: string) {
+      return originUrl;
+    },
+    rewriteS3Bucket(url: string) {
+      return url;
+    },
+    enforceCDN(url: string) {
+      return url;
+    },
+  },
+  emptyStringInsteadOfNull: false,
+  Extension: {
+    DocEncoder: {
+      encodeDocId: Extensions.encodeDocId,
+    },
+    encoders: Extensions.IDEncoders,
+  },
+  LinkResolver: {
+    buildUrl(_params: {
+      linkResolver: LinkResolver | undefined;
+      pageType: string;
+      doc?: ApiDocument;
+    }): string | undefined | null {
+      return "/";
+    },
+  },
 };
-
-type ContentType = {
-    __TYPE__: string;
-    [key: string]: any;
-};
-
-type ImageContent = {
-    origin: {
-        id: string;
-        url: string;
-        width: number,
-        height: number
-    };
-    url: string;
-    width: number;
-    height: number;
-    edit?: {
-        background: string,
-        zoom: number,
-        crop: {
-            x: number,
-            y: number
-        }
-    };
-    credits?: string | null;
-    alt?: string | null;
-    __TYPE__: string;
-    thumbnails: any;
-};
-
-type StructuredTextContent = {
-    __TYPE__: string;
-    value: Array<{
-        type: string;
-        content?: {
-            text: string;
-            spans?: Array<{
-                type: string;
-                start: number;
-                end: number;
-                data?: any;
-            }>;
-        };
-        data?: any;
-        direction?: string;
-    }>;
-};
-
-type EmbedContent = {
-    __TYPE__: string;
-    embed_url: string;
-    author_name: string;
-    author_url: string;
-    html: string;
-    type: string;
-    cache_age: string;
-    provider_name: string;
-    provider_url: string;
-    version: string;
-    width?: number;
-    height?: number;
-};
-
-type LinkContent = {
-    __TYPE__: string;
-    value: {
-        id?: string;
-        __TYPE__: string;
-        url: string;
-        name?: string;
-        kind?: string;
-        size?: string;
-        height?: string | null;
-        width?: string | null;
-    };
-};
-
-type FieldContent = {
-    __TYPE__: string;
-    value: string;
-    type: string;
-};
-
-type BooleanContent = {
-    __TYPE__: string;
-    value: boolean;
-};
-
-function transformContent(content: ContentType): AnyRegularField | null {
-    switch (content.__TYPE__) {
-        case 'ImageContent':
-            const imageContent = content as ImageContent;
-            return {
-                type: 'image',
-                url: imageContent.url,
-                alt: imageContent.alt || 'mockAlt',
-                dimensions: {
-                    width: imageContent.width,
-                    height: imageContent.height
-                }
-            };
-        case 'StructuredTextContent':
-            const structuredContent = content as StructuredTextContent;
-            return structuredContent.value.map((textNode) => {
-                if (textNode.type === 'image') {
-                    // Handle image nodes
-                    return {
-                        type: 'image',
-                        url: textNode.data.url,
-                        alt: textNode.data.alt,
-                        copyright: null,
-                        dimensions: {
-                            width: textNode.data.width,
-                            height: textNode.data.height
-                        },
-                        id: textNode.data.id,
-                        edit: {
-                            x: textNode.data.x,
-                            y: textNode.data.y,
-                            zoom: textNode.data.zoom,
-                            background: textNode.data.background
-                        }
-                    }
-                } else {
-                    const { type, content: textContent, direction } = textNode;
-                    const spansTransformed = textContent!.spans?.map(span => {
-                        switch (span.type) {
-                            case 'hyperlink':
-                                if (span.data.__TYPE__ === 'ExternalLink') {
-                                    return {
-                                        type: 'hyperlink',
-                                        start: span.start,
-                                        end: span.end,
-                                        data: {
-                                            link_type: "Web",
-                                            url: span.data.url,
-                                            target: span.data.target
-                                        }
-                                    };
-                                } else if (span.data.__TYPE__ === 'ImageLink') {
-                                    return {
-                                        type: 'hyperlink',
-                                        start: span.start,
-                                        end: span.end,
-                                        data: {
-                                            link_type: "Media",
-                                            url: span.data.url,
-                                            id: span.data.id,
-                                            name: span.data.name,
-                                            kind: "image",
-                                            size: span.data.size,
-                                            height: span.data.height,
-                                            width: span.data.width
-                                        }
-                                    };
-                                }
-                                break;
-                            default:
-                                return span;
-                        }
-                    }) || [];
-
-                    return {
-                        type: type,
-                        text: textContent!.text,
-                        spans: spansTransformed || [],
-                        direction: direction
-                    };
-                }
-            }) as [RTNode, ...RTNode[]];
-        case 'EmbedContent':
-            const embedContent = content as EmbedContent;
-            return {
-                type: 'embed',
-                embed_url: embedContent.embed_url,
-                html: embedContent.html,
-                oembed: {
-                    author_name: embedContent.author_name,
-                    author_url: embedContent.author_url,
-                    provider_name: embedContent.provider_name,
-                    provider_url: embedContent.provider_url,
-                    cache_age: embedContent.cache_age,
-                    width: embedContent.width || null,
-                    height: embedContent.height || null,
-                    version: embedContent.version
-                }
-            };
-        case 'LinkContent':
-            const linkContent = content as LinkContent;
-            if (linkContent.value.__TYPE__ === "ExternalLink") {
-                return {
-                    link_type: "Web",
-                    url: linkContent.value.url,
-                    target: "_blank"
-                };
-            }
-            else if (linkContent.value.__TYPE__ === "DocumentLink") {
-                return {
-                    "link_type": "Document"
-                }
-            }
-            else if (linkContent.value.__TYPE__ === "FileLink") {
-                return {
-                    id: linkContent.value.id,
-                    "link_type": "Media",
-                    name: linkContent.value.name,
-                    kind: linkContent.value.kind,
-                    url: linkContent.value.url,
-                    size: linkContent.value.size,
-                    height: linkContent.value.height!,
-                    width: linkContent.value.width!
-                }
-            }
-        case 'FieldContent':
-            const fieldContent = content as FieldContent;
-            return fieldContent.value;
-        case 'IntegrationFieldsContent':
-            return {}
-        case 'BooleanContent':
-            const booleanContent = content as BooleanContent;
-            return booleanContent.value;
-        default:
-            return null;
-    }
-}

--- a/app/slice-library/SliceLibraryNav.tsx
+++ b/app/slice-library/SliceLibraryNav.tsx
@@ -1,105 +1,123 @@
-'use client'
+"use client";
 import React from "react";
+
 import { Disclosure } from "@headlessui/react";
 import { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
-import { SharedSliceContent } from "@prismicio/types-internal/lib/content";
-import Image from "next/image"
+import Image from "next/image";
 import { imgixLoader } from "@prismicio/next";
 
+import { type SliceLibrary } from "./page";
+
 function classNames(...classes: string[]) {
-    return classes.filter(Boolean).join(' ')
+  return classes.filter(Boolean).join(" ");
 }
 
 export default function SliceLibraryNav({
-    libraries
+  libraries,
 }: {
-    libraries: { slices: SharedSlice[], name: string, mocks: SharedSliceContent[][] }[]
+  libraries: SliceLibrary[];
 }) {
-    return (
-        <div>
-            {/* Static sidebar for desktop */}
-            <div className="hidden md:fixed md:inset-y-0 md:flex md:w-64 md:flex-col">
-                <div className="flex flex-grow flex-col overflow-y-auto border-r border-gray-200 bg-white pt-5 pb-4">
-                    <div className="flex flex-shrink-0 items-center px-4">
-                        <Image
-                            className="h-8 w-auto"
-                            src="https://images.prismic.io/prismicio/9430ed67-a303-4fb6-85a9-bad872f3eb2a_Prismic-logo.png?auto=compress,format"
-                            alt="Prismic"
-                            width={64}
-                            height={64}
-                            loader={imgixLoader}
-                        />
-                    </div>
-                    <div className="mt-5 flex flex-grow flex-col">
-                        <nav className="flex-1 space-y-1 bg-white px-2" aria-label="Sidebar">
-                            {libraries.map((library) =>
-                                <Disclosure as="div" key={library.name} className="space-y-1">
-                                    {({ open }) => (
-                                        <>
-                                            <Disclosure.Button
-                                                className='bg-white text-gray-600 hover:bg-gray-50 hover:text-gray-900 group w-full flex items-center pr-2 py-2 text-left text-sm font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500'
-                                            >
-                                                <svg
-                                                    className={classNames(
-                                                        open ? 'text-gray-400 rotate-90' : 'text-gray-300',
-                                                        'mr-2 h-6 w-6 flex-shrink-0 transform transition-colors duration-150 ease-in-out group-hover:text-gray-400'
-                                                    )}
-                                                    viewBox="0 0 20 20"
-                                                    aria-hidden="true"
-                                                >
-                                                    <path d="M6 6L14 10L6 14V6Z" fill="currentColor" />
-                                                </svg>
-                                                {library.name}
-                                            </Disclosure.Button>
-                                            <Disclosure.Panel className="space-y-1">
-                                                {library.slices.map((slice) =>
-                                                    <Disclosure as="div" key={slice.name} className="space-y-1">
-                                                        {({ open }) => (
-                                                            <>
-                                                                <Disclosure.Button
-                                                                    className='bg-white text-gray-600 hover:bg-gray-50 hover:text-gray-900 group w-full flex items-center pl-[2rem] pr-2 py-2 text-sm font-medium rounded-md'
-                                                                >
-                                                                    <svg
-                                                                        className={classNames(
-                                                                            open ? 'text-gray-400 rotate-90' : 'text-gray-300',
-                                                                            'mr-2 h-5 w-5 flex-shrink-0 transform transition-colors duration-150 ease-in-out group-hover:text-gray-400'
-                                                                        )}
-                                                                        viewBox="0 0 20 20"
-                                                                        aria-hidden="true"
-                                                                    >
-                                                                        <path d="M6 6L14 10L6 14V6Z" fill="currentColor" />
-                                                                    </svg>
-                                                                    {slice.name}
-                                                                </Disclosure.Button>
-                                                                <Disclosure.Panel className="space-y-1">
-                                                                    {
-                                                                        slice.variations.map((variation) => {
-                                                                            return (
-                                                                                <a
-                                                                                    key={variation.id}
-                                                                                    // as="a"
-                                                                                    href={"#" + slice.id + "__" + variation.id}
-                                                                                    className="group flex w-full items-center rounded-md py-2 pl-20 pr-2 text-sm font-medium text-gray-600 hover:bg-gray-50 hover:text-gray-900"
-                                                                                >
-                                                                                    {variation.name}
-                                                                                </a>
-                                                                            )
-                                                                        })
-                                                                    }
-                                                                </Disclosure.Panel>
-                                                            </>
-                                                        )}
-                                                    </Disclosure>
-                                                )}
-                                            </Disclosure.Panel>
-                                        </>
-                                    )}
-                                </Disclosure>
-                            )}
-                        </nav>
-                    </div>
-                </div>
-            </div>
+  return (
+    <div>
+      {/* Static sidebar for desktop */}
+      <div className="hidden md:fixed md:inset-y-0 md:flex md:w-64 md:flex-col">
+        <div className="flex flex-grow flex-col overflow-y-auto border-r border-gray-200 bg-white pt-5 pb-4">
+          <div className="flex flex-shrink-0 items-center px-4">
+            <Image
+              className="h-8 w-auto"
+              src="https://images.prismic.io/prismicio/9430ed67-a303-4fb6-85a9-bad872f3eb2a_Prismic-logo.png?auto=compress,format"
+              alt="Prismic"
+              width={64}
+              height={64}
+              loader={imgixLoader}
+            />
+          </div>
+          <div className="mt-5 flex flex-grow flex-col">
+            <nav
+              className="flex-1 space-y-1 bg-white px-2"
+              aria-label="Sidebar"
+            >
+              {libraries.map((library) => (
+                <NavElementLibrary key={library.name} library={library} />
+              ))}
+            </nav>
+          </div>
         </div>
-    );
+      </div>
+    </div>
+  );
+}
+
+function NavElementLibrary({ library }: { library: SliceLibrary }) {
+  return (
+    <Disclosure as="div" className="space-y-1">
+      {({ open }) => (
+        <>
+          <Disclosure.Button className="bg-white text-gray-600 hover:bg-gray-50 hover:text-gray-900 group w-full flex items-center pr-2 py-2 text-left text-sm font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
+            <svg
+              className={classNames(
+                open ? "text-gray-400 rotate-90" : "text-gray-300",
+                "mr-2 h-6 w-6 flex-shrink-0 transform transition-colors duration-150 ease-in-out group-hover:text-gray-400"
+              )}
+              viewBox="0 0 20 20"
+              aria-hidden="true"
+            >
+              <path d="M6 6L14 10L6 14V6Z" fill="currentColor" />
+            </svg>
+            {library.name}
+          </Disclosure.Button>
+          <Disclosure.Panel className="space-y-1">
+            {library.slices.map(({ model }) => (
+              <NavElementSlice
+                key={model.name}
+                libraryName={library.name}
+                slice={model}
+              />
+            ))}
+          </Disclosure.Panel>
+        </>
+      )}
+    </Disclosure>
+  );
+}
+
+function NavElementSlice({
+  libraryName,
+  slice,
+}: {
+  libraryName: string;
+  slice: SharedSlice;
+}) {
+  return (
+    <Disclosure as="div" className="space-y-1">
+      {({ open }) => (
+        <>
+          <Disclosure.Button className="bg-white text-gray-600 hover:bg-gray-50 hover:text-gray-900 group w-full flex items-center pl-[2rem] pr-2 py-2 text-sm font-medium rounded-md">
+            <svg
+              className={classNames(
+                open ? "text-gray-400 rotate-90" : "text-gray-300",
+                "mr-2 h-5 w-5 flex-shrink-0 transform transition-colors duration-150 ease-in-out group-hover:text-gray-400"
+              )}
+              viewBox="0 0 20 20"
+              aria-hidden="true"
+            >
+              <path d="M6 6L14 10L6 14V6Z" fill="currentColor" />
+            </svg>
+            {slice.name}
+          </Disclosure.Button>
+          <Disclosure.Panel className="space-y-1">
+            {slice.variations.map((variation) => (
+              <a
+                key={variation.id}
+                href={`#${libraryName}-${slice.id}-${variation.id}`}
+                className="group flex w-full items-center rounded-md py-2 pl-20 pr-2 text-sm font-medium text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+              >
+                {variation.name}
+              </a>
+            ))}
+          </Disclosure.Panel>
+        </>
+      )}
+    </Disclosure>
+  );
 }

--- a/app/slice-library/layout.tsx
+++ b/app/slice-library/layout.tsx
@@ -1,0 +1,20 @@
+import React, { ReactNode } from "react";
+
+// Remove this, if you already import Tailwind CSS somewhere else
+import "./styles.css";
+
+// This is an example layout for the slice library page – if you have a global layout that
+// doesn't interfere with slice library styling you might not need it. Otherwise it might
+// make sense to consider multiple root layours, with this file as one of them:
+// https://nextjs.org/docs/app/building-your-application/routing/route-groups#creating-multiple-root-layouts
+export default async function SliceLibraryLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/slice-library/page.tsx
+++ b/app/slice-library/page.tsx
@@ -6,6 +6,16 @@ import { SharedSliceContent } from "@prismicio/types-internal/lib/content";
 
 import { SliceLibrary } from "./SliceLibrary";
 
+export interface SliceLibrary {
+  name: string;
+  slices: SliceWithMocks[];
+}
+
+interface SliceWithMocks {
+  model: SharedSlice;
+  mocks: Partial<Record<string, SharedSliceContent>>;
+}
+
 export async function generateMetadata(): Promise<Metadata> {
   return {
     title: "Slice Library",
@@ -13,73 +23,79 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export const dynamic = 'force-static'
+export const dynamic = "force-static";
 
 export default async function SliceLibraryPage() {
+  const libraries = await loadSliceLibraries();
 
-  const libraries = await extractModels();
-
-  return (
-    <SliceLibrary libraries={libraries} />
-  );
+  return <SliceLibrary libraries={libraries} />;
 }
 
-async function extractModels(): Promise<({ slices: SharedSlice[], name: string, mocks: SharedSliceContent[][] }[])> {
-
+// Load all the slice libraries defined for this Prismic project
+async function loadSliceLibraries(): Promise<SliceLibrary[]> {
   try {
-    const file = await fs.readFile(process.cwd() + '/slicemachine.config.json', 'utf8');
+    const file = await fs.readFile(
+      process.cwd() + "/slicemachine.config.json",
+      "utf8"
+    );
     const config = JSON.parse(file);
-    
-    const libraries =
-      await Promise.all(
-        (config.libraries || []).map(async (library: string) => {
-          return {
-            name: library,
-            slices: await readModels<SharedSlice>({
-              path: path.join(process.cwd(), library),
-              fileName: "model.json",
-            }),
-            mocks: await readModels<SharedSliceContent[]>({
-              path: path.join(process.cwd(), library),
-              fileName: "mocks.json",
-            })
-          };
-        }),
-      )
+
+    const libraries = await Promise.all(
+      (config.libraries || []).map(loadSliceLibrary)
+    );
 
     return libraries;
-  }
-  catch {
-    throw new Error("Issue when reading local slice libraries listed in slicemachine.config.json");
+  } catch {
+    throw new Error(
+      "Issue when reading local slice libraries listed in slicemachine.config.json"
+    );
   }
 }
 
-const readModels = async <TType extends SharedSliceContent[] | SharedSlice>(args: {
-  path: string;
-  fileName: string;
-}): Promise<TType[]> => {
-  const entries = await fs.readdir(args.path, {
+// Load all slices and their associated mocks for the given slice library
+async function loadSliceLibrary(library: string): Promise<SliceLibrary> {
+  const libraryPath = path.join(process.cwd(), library);
+  const entries = await fs.readdir(libraryPath, {
     recursive: true,
     withFileTypes: true,
   });
 
-  const results: TType[] = [];
+  const slices: SliceWithMocks[] = [];
 
-  //Order slices alphabetically in each library
-  entries.sort((a,b)=> a.path>b.path ? 1 : -1)
+  // Order slices alphabetically in each library
+  entries.sort((a, b) => (a.path > b.path ? 1 : -1));
 
   for (const entry of entries) {
-    if (entry.name !== args.fileName || entry.isDirectory()) {
+    if (entry.name !== "model.json" || entry.isDirectory()) {
       continue;
     }
 
-    const contents = await fs.readFile(
-      path.join(entry.path, entry.name),
-      "utf8",
-    );
+    const modelPath = path.join(entry.path, entry.name);
+    const mocksPath = path.join(entry.path, "mocks.json");
 
-    results.push(JSON.parse(contents));
+    const modelContents = await fs.readFile(modelPath, "utf8");
+    const model = JSON.parse(modelContents) as SharedSlice;
+    const mocks: SliceWithMocks["mocks"] = {};
+
+    // Read mocks for the given slice – if mocks are not present, ignore that;
+    // the Slice Library components will display an empty placeholder in that case
+    try {
+      const mocksContents = await fs.readFile(mocksPath, "utf-8");
+      const mocksJson = JSON.parse(mocksContents) as SharedSliceContent[];
+
+      // Create a map from variation name to it's mocks for easy access in components
+      for (const { id } of model.variations) {
+        const mock = mocksJson.find(({ variation }) => variation === id);
+
+        mocks[id] = mock;
+      }
+    } catch (e) {}
+
+    slices.push({ model, mocks });
   }
 
-  return results;
-};
+  return {
+    name: library,
+    slices,
+  };
+}

--- a/app/slice-library/styles.css
+++ b/app/slice-library/styles.css
@@ -1,0 +1,5 @@
+/* Feel free to remove this file, if Tailwind CSS styles are already
+ * available globally in your project */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@growthbook/growthbook-react": "^0.18.0",
         "@headlessui/react": "^1.7.19",
         "@heroicons/react": "^2.0.17",
+        "@prismicio/api-renderer": "^3.1.0",
         "@prismicio/client": "^7.5.0",
         "@prismicio/next": "^1.5.0",
         "@prismicio/react": "^2.7.4",
@@ -543,14 +544,13 @@
       }
     },
     "node_modules/@prismicio/api-renderer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@prismicio/api-renderer/-/api-renderer-1.0.0.tgz",
-      "integrity": "sha512-dD74209FaT4JB+pZkLP+69u5rFqzcuNQU9aBMN9sQ4usSbScuSbNdXL1hVasAite5r+hIiphskfxaxdfqPvDIw==",
-      "dev": true,
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@prismicio/api-renderer/-/api-renderer-3.1.0.tgz",
+      "integrity": "sha512-pqEA8uL0bz7y2cG/b7lRRhtkwcoWGz38otGjDq3JIrvZDm5cwtaBLDtUKdnRAELtMhsqG28D66doEYgF6BLZwQ==",
       "dependencies": {
-        "@prismicio/types-internal": "^1.0.1",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
+        "@prismicio/types-internal": "2.4.1",
+        "tslib": "^2.5.0",
+        "uuid": "^9.0.0"
       },
       "engines": {
         "node": ">=12.7.0"
@@ -559,34 +559,6 @@
         "fp-ts": "^2.11.8",
         "io-ts": "^2.2.16",
         "io-ts-types": "^0.5.16"
-      }
-    },
-    "node_modules/@prismicio/api-renderer/node_modules/@prismicio/types-internal": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@prismicio/types-internal/-/types-internal-1.5.3.tgz",
-      "integrity": "sha512-GHV2rZsCUJJQDF7gF2to0F/3eolTXD/ng7ClfbqtHO3udJ5D+iifocAEnsEdi+Y9VKT/WVgyBi/dA6GAhNMHmQ==",
-      "dev": true,
-      "dependencies": {
-        "monocle-ts": "^2.3.11",
-        "newtype-ts": "^0.3.5",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.7.0"
-      },
-      "peerDependencies": {
-        "fp-ts": "^2.11.8",
-        "io-ts": "^2.2.16",
-        "io-ts-types": "^0.5.16"
-      }
-    },
-    "node_modules/@prismicio/api-renderer/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@prismicio/client": {
@@ -631,6 +603,44 @@
       },
       "engines": {
         "node": ">=12.7.0"
+      }
+    },
+    "node_modules/@prismicio/mocks/node_modules/@prismicio/api-renderer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@prismicio/api-renderer/-/api-renderer-1.0.0.tgz",
+      "integrity": "sha512-dD74209FaT4JB+pZkLP+69u5rFqzcuNQU9aBMN9sQ4usSbScuSbNdXL1hVasAite5r+hIiphskfxaxdfqPvDIw==",
+      "dev": true,
+      "dependencies": {
+        "@prismicio/types-internal": "^1.0.1",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "fp-ts": "^2.11.8",
+        "io-ts": "^2.2.16",
+        "io-ts-types": "^0.5.16"
+      }
+    },
+    "node_modules/@prismicio/mocks/node_modules/@prismicio/api-renderer/node_modules/@prismicio/types-internal": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@prismicio/types-internal/-/types-internal-1.5.3.tgz",
+      "integrity": "sha512-GHV2rZsCUJJQDF7gF2to0F/3eolTXD/ng7ClfbqtHO3udJ5D+iifocAEnsEdi+Y9VKT/WVgyBi/dA6GAhNMHmQ==",
+      "dev": true,
+      "dependencies": {
+        "monocle-ts": "^2.3.11",
+        "newtype-ts": "^0.3.5",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "fp-ts": "^2.11.8",
+        "io-ts": "^2.2.16",
+        "io-ts-types": "^0.5.16"
       }
     },
     "node_modules/@prismicio/mocks/node_modules/@prismicio/types-internal": {
@@ -731,7 +741,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@prismicio/types-internal/-/types-internal-2.4.1.tgz",
       "integrity": "sha512-xJCrXvitu3Rs/hMWxraxE2gOYDqGV/6hFudhu4EL3fX3HIXPxFzGngtzOPTPz7NIqdEswj10ByTyLQYRR060Tw==",
-      "dev": true,
       "dependencies": {
         "monocle-ts": "^2.3.11",
         "newtype-ts": "^0.3.5",
@@ -1213,7 +1222,6 @@
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true,
       "peer": true
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -3514,8 +3522,7 @@
     "node_modules/fp-ts": {
       "version": "2.16.5",
       "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.5.tgz",
-      "integrity": "sha512-N8T8PwMSeTKKtkm9lkj/zSTAnPC/aJIIrQhnHxxkL0KLsRCNUPANksJOlMXxcKKCo7H1ORP3No9EMD+fP0tsdA==",
-      "dev": true
+      "integrity": "sha512-N8T8PwMSeTKKtkm9lkj/zSTAnPC/aJIIrQhnHxxkL0KLsRCNUPANksJOlMXxcKKCo7H1ORP3No9EMD+fP0tsdA=="
     },
     "node_modules/fraction.js": {
       "version": "4.3.7",
@@ -4106,7 +4113,6 @@
       "version": "2.2.21",
       "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.21.tgz",
       "integrity": "sha512-zz2Z69v9ZIC3mMLYWIeoUcwWD6f+O7yP92FMVVaXEOSZH1jnVBmET/urd/uoarD1WGBY4rCj8TAyMPzsGNzMFQ==",
-      "dev": true,
       "peerDependencies": {
         "fp-ts": "^2.5.0"
       }
@@ -4128,7 +4134,6 @@
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.5.19.tgz",
       "integrity": "sha512-kQOYYDZG5vKre+INIDZbLeDJe+oM+4zLpUkjXyTMyUfoCpjJNyi29ZLkuEAwcPufaYo3yu/BsemZtbdD+NtRfQ==",
-      "dev": true,
       "peerDependencies": {
         "fp-ts": "^2.0.0",
         "io-ts": "^2.0.0",
@@ -5031,7 +5036,6 @@
       "version": "2.3.13",
       "resolved": "https://registry.npmjs.org/monocle-ts/-/monocle-ts-2.3.13.tgz",
       "integrity": "sha512-D5Ygd3oulEoAm3KuGO0eeJIrhFf1jlQIoEVV2DYsZUMz42j4tGxgct97Aq68+F8w4w4geEnwFa8HayTS/7lpKQ==",
-      "dev": true,
       "peerDependencies": {
         "fp-ts": "^2.5.0"
       }
@@ -5100,7 +5104,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/newtype-ts/-/newtype-ts-0.3.5.tgz",
       "integrity": "sha512-v83UEQMlVR75yf1OUdoSFssjitxzjZlqBAjiGQ4WJaML8Jdc68LJ+BaSAXUmKY4bNzp7hygkKLYTsDi14PxI2g==",
-      "dev": true,
       "peerDependencies": {
         "fp-ts": "^2.0.0",
         "monocle-ts": "^2.0.0"
@@ -7570,12 +7573,10 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@growthbook/growthbook-react": "^0.18.0",
     "@headlessui/react": "^1.7.19",
     "@heroicons/react": "^2.0.17",
+    "@prismicio/api-renderer": "^3.1.0",
     "@prismicio/client": "^7.5.0",
     "@prismicio/next": "^1.5.0",
     "@prismicio/react": "^2.7.4",

--- a/slices/CallToAction/mocks.json
+++ b/slices/CallToAction/mocks.json
@@ -142,7 +142,7 @@
 					"background": "transparent"
 				},
 				"credits": null,
-				"alt": null,
+				"alt": "Lorem ipsum dolor sit amet",
 				"__TYPE__": "ImageContent",
 				"thumbnails": {}
 			}
@@ -247,7 +247,7 @@
 					"background": "transparent"
 				},
 				"credits": null,
-				"alt": null,
+				"alt": "Lorem ipsum dolor sit amet",
 				"__TYPE__": "ImageContent",
 				"thumbnails": {}
 			}

--- a/slices/Features/mocks.json
+++ b/slices/Features/mocks.json
@@ -85,7 +85,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -127,7 +127,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -204,7 +204,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -230,7 +230,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -307,7 +307,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -333,7 +333,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -428,7 +428,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -470,7 +470,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -547,7 +547,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -573,7 +573,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -650,7 +650,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -676,7 +676,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -771,7 +771,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -1051,7 +1051,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}

--- a/slices/Form/mocks.json
+++ b/slices/Form/mocks.json
@@ -134,7 +134,7 @@
                 }
               },
               "credits": null,
-              "alt": null,
+              "alt": "Lorem ipsum dolor sit amet",
               "__TYPE__": "ImageContent",
               "thumbnails": {}
             }
@@ -229,7 +229,7 @@
                 }
               },
               "credits": null,
-              "alt": null,
+              "alt": "Lorem ipsum dolor sit amet",
               "__TYPE__": "ImageContent",
               "thumbnails": {}
             }

--- a/slices/JobList/mocks.json
+++ b/slices/JobList/mocks.json
@@ -51,7 +51,7 @@
 					"background": "transparent"
 				},
 				"credits": null,
-				"alt": null,
+				"alt": "Lorem ipsum dolor sit amet",
 				"__TYPE__": "ImageContent",
 				"thumbnails": {}
 			},

--- a/slices/Testimonials/mocks.json
+++ b/slices/Testimonials/mocks.json
@@ -103,7 +103,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -182,7 +182,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -261,7 +261,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -340,7 +340,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -419,7 +419,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -498,7 +498,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -611,7 +611,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -690,7 +690,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -769,7 +769,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -848,7 +848,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -927,7 +927,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -1006,7 +1006,7 @@
 								}
 							},
 							"credits": null,
-							"alt": null,
+							"alt": "Lorem ipsum dolor sit amet",
 							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
@@ -1220,7 +1220,7 @@
 					"background": "transparent"
 				},
 				"credits": null,
-				"alt": null,
+				"alt": "Lorem ipsum dolor sit amet",
 				"__TYPE__": "ImageContent",
 				"thumbnails": {}
 			},
@@ -1282,7 +1282,7 @@
 					"background": "transparent"
 				},
 				"credits": null,
-				"alt": null,
+				"alt": "Lorem ipsum dolor sit amet",
 				"__TYPE__": "ImageContent",
 				"thumbnails": {}
 			}
@@ -1356,7 +1356,7 @@
 					"background": "transparent"
 				},
 				"credits": null,
-				"alt": null,
+				"alt": "Lorem ipsum dolor sit amet",
 				"__TYPE__": "ImageContent",
 				"thumbnails": {}
 			}


### PR DESCRIPTION
What was done:

  * replaced `mapEditorToAPIFormat` with native Prismic solution using `@prismicio/api-renderer` to simplify the code (the `@prismicio/types-internal` were not sufficient themselves),
  * simplified mock and model loading a bit by combining the slice data with it's mock data as to avoid having to do parallel array indexing later,
  * split big components into smaller ones and re-formatted the code,
  * added default `style.css` and `layout.tsx` to simplify setup if someone isn't using Tailwind CSS yet or has an invasive default layout and needs an alternative basic one,
  * improved the readme — edited and clarified wording, added explanations on what to do if you don't use TypeScript or Tailwind CSS,
  * added minor visual improvements that make it clearer how big a given slice is (they are optional and put in a separate commit, should you not want them).